### PR TITLE
Improve package name parsing in debuntu-kernel-manager*

### DIFF
--- a/debuntu_tools/__init__.py
+++ b/debuntu_tools/__init__.py
@@ -1,7 +1,7 @@
 # Debian and Ubuntu system administration tools.
 #
 # Author: Peter Odding <peter@peterodding.com>
-# Last Change: January 18, 2017
+# Last Change: April 17, 2017
 # URL: https://debuntu-tools.readthedocs.io
 
 """
@@ -13,4 +13,4 @@ The top level :mod:`debuntu_tools` module contains only a version number.
 """
 
 # Semi-standard module versioning.
-__version__ = '0.3.6'
+__version__ = '0.3.7'


### PR DESCRIPTION
Recently I installed the Linux kernel image meta package
linux-image-generic-hwe-16.04 on my Ubuntu 16.04 laptop
and since then I noticed that debuntu-kernel-manager got
confused by the -16.04 suffix. This is now fixed.